### PR TITLE
generalising the infoBanner

### DIFF
--- a/addon/components/info-banner-container.js
+++ b/addon/components/info-banner-container.js
@@ -1,0 +1,5 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  classNames: ['info-banner-container'],
+});

--- a/addon/styles/_info-banner.scss
+++ b/addon/styles/_info-banner.scss
@@ -20,6 +20,10 @@ $white: #fdfdfd;
   &.hidden {
     display: none;
   }
+
+  &.survey {
+    background-color: #1e719b;
+  }
 }
 .info-banner-container {
   width: 960px;

--- a/addon/templates/components/info-banner.hbs
+++ b/addon/templates/components/info-banner.hbs
@@ -1,7 +1,5 @@
 {{#if config.link}}
-  <div class="info-banner-wrapper">
-    <div class="info-banner-container">
-      This is a preview of Octane, an upcoming edition of Ember.js! Go <a href={{config.link}} target="_blank" rel="noopener">{{config.title}}</a> to help out and learn more.
-    </div>
+  <div class="info-banner-wrapper {{type}}">
+    {{yield (hash container=(component 'info-banner-container') config=config)}}
   </div>
 {{/if}}

--- a/app/components/info-banner-container.js
+++ b/app/components/info-banner-container.js
@@ -1,0 +1,1 @@
+export { default } from 'guidemaker-ember-template/components/info-banner-container';

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -8,7 +8,17 @@
   {{/es-navbar}}
 {{/es-header}}
 
-{{info-banner}}
+{{#info-banner type="survey" configName="survey" as |ui|}}
+  {{#ui.container}}
+    Take the <a href={{ui.config.link}} target="_blank" rel="noopener">{{ui.config.title}}</a>
+  {{/ui.container}}
+{{/info-banner}}
+
+{{#info-banner configName="infoBanner" as |ui|}}
+  {{#ui.container}}
+    This is a preview of Octane, an upcoming edition of Ember.js! Go <a href={{ui.config.link}} target="_blank" rel="noopener">{{ui.config.title}}</a> to help out and learn more.
+  {{/ui.container}}
+{{/info-banner}}
 
 <main class="container">
   {{outlet}}


### PR DESCRIPTION
This just extends #12 so that it doesn't **delete** the functionality to add the survey banner. I'm just thinking that it would be useful to still have there next year 😉 