### PR TITLE
remove unsupported node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "qunit-dom": "^0.6.2"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This PR matches the upstream PR: https://github.com/empress/guidemaker/pull/15

@mansona highlighted that prember does not support node < 8 in the following post:
ember-learn/guides-app#402 (comment)
This project depends on the guidemaker project, which in turn has prember as a dependency, so it makes sense to remove node 6 from the engines tag and only support 8+