### PR TITLE
don't include removal diff in copy-paste code, fix tests

### DIFF
--- a/addon/controllers/error.js
+++ b/addon/controllers/error.js
@@ -1,0 +1,9 @@
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
+
+export default Controller.extend({
+  hasErrors: computed('model.errors.0.status', function() {
+    let errors = this.model.errors.firstObject.status;
+    return errors.contains("404") || errors.contains("403");
+  })
+});

--- a/addon/controllers/error.js
+++ b/addon/controllers/error.js
@@ -3,6 +3,10 @@ import { computed } from '@ember/object';
 
 export default Controller.extend({
   hasErrors: computed('model.errors.0.status', function() {
+    if (!this.model || !Array.isArray(this.model.errors) || this.model.errors.length) {
+      // if there is no error field, skip this
+      return;
+    }
     let errors = this.model.errors.firstObject.status;
     return errors.contains("404") || errors.contains("403");
   })

--- a/addon/styles/_prism-overrides.scss
+++ b/addon/styles/_prism-overrides.scss
@@ -28,12 +28,12 @@ code > .diff-deletion {
   }
 }
 
-code .diff-operator {
-  user-select: none;
-}
-
+// don't include "removed" code when copy-pasting diffs
+code .diff-operator,
 code .diff-deletion {
-  // don't include removed code in copy-paste
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
   user-select: none;
 }
 

--- a/addon/styles/_prism-overrides.scss
+++ b/addon/styles/_prism-overrides.scss
@@ -32,6 +32,11 @@ code .diff-operator {
   user-select: none;
 }
 
+code .diff-deletion {
+  // don't include removed code in copy-paste
+  user-select: none;
+}
+
 code .token.comment {
   color: #E6E6E6;
 }

--- a/app/controllers/error.js
+++ b/app/controllers/error.js
@@ -1,0 +1,1 @@
+export { default } from 'guidemaker-ember-template/controllers/error';

--- a/app/templates/error.hbs
+++ b/app/templates/error.hbs
@@ -1,5 +1,5 @@
 <article class="x404" data-test-error-page>
-  {{#if (contains model.errors.0.status (array "404" "403"))}}
+  {{#if this.hasErrors}}
     <img src="/images/fishy.png" title="ACK! 404 FRIEND, YOU'RE IN THE WRONG PLACE" alt="A Tomster mascot holding a fish that has been outside in the sun too long!">
     <h1 class="whoops" data-test-error-message>Ack! 404 friend, you're in the wrong place</h1>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6967,9 +6967,9 @@
       }
     },
     "ember-composable-helpers": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/ember-composable-helpers/-/ember-composable-helpers-2.3.1.tgz",
-      "integrity": "sha512-Eltj5yt2CtHhBMrdsjKQTP1zFyfEXQ5/v85ObV2zh0eIJZa1t/gImHN+GIHHuJ+9xOrCUAy60/2TJZjadpoPBQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/ember-composable-helpers/-/ember-composable-helpers-3.1.1.tgz",
+      "integrity": "sha512-lPmPhk4wIg1JDnuOfzcDzrCZoaDoTvZrYVaBi4Eia2SdEEfcDNipQTXTk0yHFCvKfSjXjuNlTtNP9UANH58TzQ==",
       "requires": {
         "@babel/core": "^7.0.0",
         "broccoli-funnel": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-sass": "^10.0.0",
     "ember-cli-showdown": "^4.4.4",
     "ember-collapsible-panel": "^3.1.1",
-    "ember-composable-helpers": "^2.1.0",
+    "ember-composable-helpers": "^3.1.0",
     "ember-href-to": "^3.1.0",
     "ember-power-select": "^2.0.9",
     "ember-prism": "^0.4.0",


### PR DESCRIPTION
This PR makes it so that the removal diff isn't copy-pasted.

Before (all text can be highlighted for copy-paste):
<img width="856" alt="Screen Shot 2019-11-06 at 11 09 34 AM" src="https://user-images.githubusercontent.com/16627268/68315553-ef14f580-0085-11ea-9152-f6e14c65e248.png">

After (red diff text is excluded from copy-paste):
<img width="850" alt="Screen Shot 2019-11-06 at 11 09 06 AM" src="https://user-images.githubusercontent.com/16627268/68315522-e1f80680-0085-11ea-8c62-3e015c344158.png">

See https://github.com/ember-learn/super-rentals-tutorial/issues/106 for motivation.