### PR TITLE
removing ember-composible-helpers to fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,6 @@ env:
     - JOBS=1
     - PERCY_ENABLE=0 # disable percy by default
 
-branches:
-  only:
-    - master
-    # npm version tags
-    - /^v\d+\.\d+\.\d+/
-
 jobs:
   fail_fast: true
   allow_failures:

--- a/addon/helpers/contains.js
+++ b/addon/helpers/contains.js
@@ -1,0 +1,24 @@
+import { A as emberArray } from '@ember/array';
+import { isArray as isEmberArray } from '@ember/array';
+import { helper } from '@ember/component/helper';
+import includes from '../utils/includes';
+
+function _contains(needle, haystack) {
+  return includes(emberArray(haystack), needle);
+}
+
+export function contains(needle, haystack) {
+  if (!isEmberArray(haystack)) {
+    return false;
+  }
+
+  if (isEmberArray(needle)) {
+    return needle.reduce((acc, val) => acc && _contains(val, haystack), true);
+  }
+
+  return _contains(needle, haystack);
+}
+
+export default helper(function([needle, haystack]) {
+  return contains(needle, haystack);
+});

--- a/addon/helpers/inc.js
+++ b/addon/helpers/inc.js
@@ -1,0 +1,23 @@
+import { helper } from '@ember/component/helper';
+import { isEmpty } from '@ember/utils';
+
+export function inc([step, val]) {
+  if (isEmpty(val)) {
+    val = step;
+    step = undefined;
+  }
+
+  val = Number(val);
+
+  if (isNaN(val)) {
+    return;
+  }
+
+  if (step === undefined) {
+    step = 1;
+  }
+
+  return val + step;
+}
+
+export default helper(inc);

--- a/app/helpers/contains.js
+++ b/app/helpers/contains.js
@@ -1,0 +1,1 @@
+export { default, contains } from 'guidemaker-ember-template/helpers/contains';

--- a/app/helpers/inc.js
+++ b/app/helpers/inc.js
@@ -1,0 +1,1 @@
+export { default, inc } from 'guidemaker-ember-template/helpers/inc';

--- a/package-lock.json
+++ b/package-lock.json
@@ -7288,6 +7288,54 @@
         }
       }
     },
+    "ember-array-helper": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ember-array-helper/-/ember-array-helper-5.1.0.tgz",
+      "integrity": "sha512-inSnELMADOgX46ipx7E1jcAOFLxQ0X1AqaaoEZfn9TFEzwgx0PMYZL7i5YbEfNqpMswmO8sbMZeW4hxKvEycnw==",
+      "dev": true,
+      "requires": {
+        "ember-cli-babel": "^7.1.2",
+        "ember-cli-version-checker": "^4.1.0"
+      },
+      "dependencies": {
+        "ember-cli-version-checker": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-4.1.0.tgz",
+          "integrity": "sha512-yLf2YqotTSsjiXwx9Dt6H7AU0QcldFn5SLk/pG3Zqb0aHNeanBOPlx4/Ysa46ILGWYIh0fDH34AEVRueXTrQBQ==",
+          "dev": true,
+          "requires": {
+            "resolve-package-path": "^2.0.0",
+            "semver": "^6.3.0",
+            "silent-error": "^1.1.1"
+          }
+        },
+        "resolve": {
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "resolve-package-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-package-path/-/resolve-package-path-2.0.0.tgz",
+          "integrity": "sha512-/CLuzodHO2wyyHTzls5Qr+EFeG6RcW4u6//gjYvUfcfyuplIX1SSccU+A5A9A78Gmezkl3NBkFAMxLbzTY9TJA==",
+          "dev": true,
+          "requires": {
+            "path-root": "^0.1.1",
+            "resolve": "^1.13.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
     "ember-assign-polyfill": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/ember-assign-polyfill/-/ember-assign-polyfill-2.6.0.tgz",
@@ -8941,39 +8989,6 @@
         "babel-plugin-debug-macros": "^0.2.0",
         "ember-cli-version-checker": "^2.1.1",
         "semver": "^5.4.1"
-      }
-    },
-    "ember-composable-helpers": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/ember-composable-helpers/-/ember-composable-helpers-2.3.1.tgz",
-      "integrity": "sha512-Eltj5yt2CtHhBMrdsjKQTP1zFyfEXQ5/v85ObV2zh0eIJZa1t/gImHN+GIHHuJ+9xOrCUAy60/2TJZjadpoPBQ==",
-      "requires": {
-        "@babel/core": "^7.0.0",
-        "broccoli-funnel": "2.0.1",
-        "ember-cli-babel": "^7.1.0",
-        "resolve": "^1.10.0"
-      },
-      "dependencies": {
-        "broccoli-funnel": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
-          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
-          "requires": {
-            "array-equal": "^1.0.0",
-            "blank-object": "^1.0.1",
-            "broccoli-plugin": "^1.3.0",
-            "debug": "^2.2.0",
-            "fast-ordered-set": "^1.0.0",
-            "fs-tree-diff": "^0.5.3",
-            "heimdalljs": "^0.2.0",
-            "minimatch": "^3.0.0",
-            "mkdirp": "^0.5.0",
-            "path-posix": "^1.0.0",
-            "rimraf": "^2.4.3",
-            "symlink-or-copy": "^1.0.0",
-            "walk-sync": "^0.3.1"
-          }
-        }
       }
     },
     "ember-concurrency": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "ember-cli-sass": "^10.0.0",
     "ember-cli-showdown": "^4.4.4",
     "ember-collapsible-panel": "^3.1.1",
-    "ember-composable-helpers": "^2.1.0",
     "ember-href-to": "^3.1.0",
     "ember-power-select": "^2.0.9",
     "ember-prism": "^0.4.0",
@@ -41,6 +40,7 @@
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
     "broccoli-asset-rev": "^3.0.0",
+    "ember-array-helper": "^5.1.0",
     "ember-cli": "~3.12.0",
     "ember-cli-dependency-checker": "^3.1.0",
     "ember-cli-eslint": "^5.1.0",


### PR DESCRIPTION
This PR (finally) gets CI running on PRs to the redesign branch and fixes build for recent ember versions because of the array helper override error 👍 