### PR TITLE
Prevent a re-render from duplicating diff ops

### DIFF
--- a/addon/styles/_prism-overrides.scss
+++ b/addon/styles/_prism-overrides.scss
@@ -29,7 +29,6 @@ code > .diff-deletion {
 }
 
 // don't include "removed" code when copy-pasting diffs
-code .diff-operator,
 code .diff-deletion {
   -moz-user-select: none;
   -webkit-user-select: none;

--- a/app/components/guides-article.js
+++ b/app/components/guides-article.js
@@ -107,9 +107,9 @@ export default Component.extend({
         let lineNo = +(pD.replace(operator, ''));
         let text = lines[lineNo - 1];
         if (operator === '+') {
-          lines[lineNo - 1] = `<span class="diff-insertion"><span class="diff-operator">+</span>${text}</span>`;
+          lines[lineNo - 1] = `<span class="diff-insertion">${text}</span>`;
         } else {
-          lines[lineNo - 1] = `<span class="diff-deletion"><span class="diff-operator">-</span>${text}</span>`;
+          lines[lineNo - 1] = `<span class="diff-deletion">${text}</span>`;
         }
       });
       codeBlock.innerHTML = lines.join('\n');

--- a/tests/dummy/guides/release/examples/syntax-highlighting.md
+++ b/tests/dummy/guides/release/examples/syntax-highlighting.md
@@ -47,7 +47,8 @@ export default Router;
 </div>
 ```
 
-```handlebars {data-filename="app/templates/application.hbs" data-diff="-1,-2,-3"}
+## Code Diff
+```handlebars { data-filename="app/templates/application.hbs" data-diff="+1,-3" }
 {{!-- The following component displays Ember's default welcome message. --}}
 <WelcomePage />
 {{!-- Feel free to remove this! --}}


### PR DESCRIPTION
While investigating https://github.com/ember-learn/guides-source/issues/1548 I noticed that we are wrapping the diffs in a couple of DOM elements.

```
if (operator === '+') {
  lines[lineNo - 1] = `<span class="diff-insertion"><span class="diff-operator">+</span>${text}</span>`;
} else {
  lines[lineNo - 1] = `<span class="diff-deletion"><span class="diff-operator">-</span>${text}</span>`;
}
```

This is fine when it is first rendered. However, if the `didRender` event fires again, the `Prism.highlightAll();` fires again, but this time with the wrapped code. Since the wrapped code includes a DOM element with innerText (`.diff-operator`), this diff operator is included, and then we wrap it again, resulting in multiple ops for diffs.

I removed the `<span class="diff-operator">*</span>` since it was a user hidden element, and didn't seem to be used anywhere else.
