### PR TITLE
Add top padding to toc-container after versions select

### DIFF
--- a/addon/styles/_table-of-contents.scss
+++ b/addon/styles/_table-of-contents.scss
@@ -77,6 +77,7 @@ label[for="toc-toggle"]:after {
 
 .toc-container.versions {
   border-top: 1px solid #F8E7CF;
+  padding-top: 1em;
 }
 
 .toc-container {


### PR DESCRIPTION
I think there's also a redesign in the works? So feel free to close if this isn't needed.

Before:
<img width="286" alt="Screenshot 2021-03-06 at 12 23 59" src="https://user-images.githubusercontent.com/7403183/110205110-ed746100-7e76-11eb-8a09-7b12a0aaab8b.png">

After:
<img width="284" alt="Screenshot 2021-03-06 at 12 24 20" src="https://user-images.githubusercontent.com/7403183/110205120-f5340580-7e76-11eb-8330-94a2bf03cbaa.png">