### PR TITLE
Add support for "main" branches in edit URLs

### DIFF
--- a/app/templates/components/guides-article.hbs
+++ b/app/templates/components/guides-article.hbs
@@ -8,7 +8,7 @@
 
 {{#if guidemaker.sourceRepo}}
   <a
-    href="{{guidemaker.sourceRepo}}/edit/master/guides/{{editVersion}}{{model.id}}.md"
+    href="{{guidemaker.sourceRepo}}/edit/{{or guidemaker.sourceBranch "master"}}/guides/{{editVersion}}{{model.id}}.md"
     target="_blank"
     class="edit-page icon-pencil"
     rel="noopener"

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "ember-try": "^1.2.1",
         "eslint-plugin-ember": "^7.1.0",
         "eslint-plugin-node": "^10.0.0",
-        "guidemaker": "^2.0.0",
+        "guidemaker": "^2.5.0",
         "loader.js": "^4.7.0",
         "npm-run-all": "^4.1.5",
         "prember": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "ember-try": "^1.2.1",
     "eslint-plugin-ember": "^7.1.0",
     "eslint-plugin-node": "^10.0.0",
-    "guidemaker": "^2.0.0",
+    "guidemaker": "^2.5.0",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",
     "prember": "^1.0.2",


### PR DESCRIPTION
Closes #76

@mansona is there a nicer way to pass this config variable? I would like to add this info to the CLI Guides.

cc @ijlee2 

How to test:
1. Run the app locally
2. In `app/templates/components/guides-article.hbs`, copy the "edit page" link markup and paste it into the template outside of the if statement. See that it has "main" in the path
3. Edit the dummy app config to remove the guidemaker-ember-template section
4. Restart the app, and look at the url. It should say `master` in it.

`master` is the default, so this is a non-breaking minor change.