### PR TITLE
"New" design side menu

### DIFF
--- a/addon/styles/table-of-contents.css
+++ b/addon/styles/table-of-contents.css
@@ -1,3 +1,10 @@
+/* All the .es-sidebar styling should probably move to the ember-styleguide when we agree this is the right thing to do */
+.es-sidebar {
+  border-right: 1px solid var(--color-gray-700);
+  padding: 24px 24px 0 0;
+  margin: -70px 0 -70px 0;
+}
+
 .table-of-contents {
   list-style-type: none;
   padding-left: 0;
@@ -16,22 +23,8 @@
   margin-bottom: 0;
 }
 
-.sub-table-of-contents .sub-table-of-contents li {
-  list-style-image: url("/rect.svg")
-}
-
 .table-of-contents a:link {
   background: none;
-}
-
-.sub-table-of-contents .toc-item .link-text {
-  transition: transform .3s;
-  display: block;
-}
-
-.sub-table-of-contents .toc-link:hover .link-text,
-.sub-table-of-contents .toc-group[aria-expanded=false]:hover .link-text {
-  transform: translateX(6px);
 }
 
 .sub-table-of-contents .toc-item a  {
@@ -39,23 +32,23 @@
   padding: var(--spacing-1);
   border-radius: var(--radius);
   line-height: var(--line-height-xs);
+  color: var(--color-gray-700);
+  border-left: 0 solid transparent;
+  transition: border-width .3s;
 }
 
-.sub-table-of-contents .toc-link.selected > a  {
-  border-left-color: var(--color-gray-300);
-  background-color: var(--color-gray-300);
+.sub-table-of-contents .toc-item a:hover {
+  border-left: 4px solid var(--color-gray-400);
+  border-radius: 0;
 }
 
-.sub-table-of-contents .toc-link.selected:hover {
-  border-left-width: 0;
-  padding-left: 0;
-  margin-right: 0;
+.sub-table-of-contents .toc-item.selected > a  {
+  border-left: 4px solid var(--color-brand-hc-dark);
+  border-radius: 0;
 }
-
 
 .table-of-contents li {
   margin: 3px 0;
-  border-left: 0 solid transparent;
 }
 
 li.toc-heading {

--- a/addon/styles/table-of-contents.css
+++ b/addon/styles/table-of-contents.css
@@ -2,7 +2,7 @@
 .es-sidebar {
   border-right: 1px solid var(--color-gray-700);
   padding: var(--spacing-4) var(--spacing-4) 0 0;
-  margin: calc(-1 * var(--spacing-6)) 0 calc(-1 * var(--spacing-6) - 32px); /* the -32 is a bit magical */
+  margin: calc(-1 * var(--spacing-6)) 0 calc(-1 * var(--spacing-6));
 }
 
 .table-of-contents {

--- a/addon/styles/table-of-contents.css
+++ b/addon/styles/table-of-contents.css
@@ -1,8 +1,8 @@
 /* All the .es-sidebar styling should probably move to the ember-styleguide when we agree this is the right thing to do */
 .es-sidebar {
   border-right: 1px solid var(--color-gray-700);
-  padding: 24px 24px 0 0;
-  margin: -70px 0 -70px 0;
+  padding: var(--spacing-4) var(--spacing-4) 0 0;
+  margin: calc(-1 * var(--spacing-6)) 0 calc(-1 * var(--spacing-6) - 32px); /* the -32 is a bit magical */
 }
 
 .table-of-contents {


### PR DESCRIPTION
Improved the Table of Content as discussed in #85. Made a version that looked similar to the current side bar.
<img width="1053" alt="Screenshot 2022-05-17 at 09 28 17" src="https://user-images.githubusercontent.com/5811560/168754230-40c6a1f0-c6f2-4d6f-b8b0-66a2b2a45144.png">

https://user-images.githubusercontent.com/5811560/168754237-5355f620-0468-4b2b-b958-f43bf6410a8f.mov

**To discuss**
* I've not changed the width of the sidebar for now, I think that making it wider including the other content could benefit, but that would require overriding variables from style guide to make it look like the screenshot below. Imho it's not necessary yet.

## Future option
<img width="1494" alt="Screenshot 2022-05-17 at 09 00 11" src="https://user-images.githubusercontent.com/5811560/168751766-9d343b15-1561-4bf2-ab47-9f75c46b0c6c.png">
