### PR TITLE
run angle-brackets-codemod

### DIFF
--- a/addon/templates/components/info-banner.hbs
+++ b/addon/templates/components/info-banner.hbs
@@ -2,7 +2,7 @@
 {{#if this.config}}
   <div class="info-banner-wrapper">
     <div class="info-banner-container">
-      {{markdown-to-html this.config.content}}
+      <MarkdownToHtml @markdown={{this.config.content}} />
     </div>
   </div>
 {{/if}}

--- a/addon/templates/components/search-input.hbs
+++ b/addon/templates/components/search-input.hbs
@@ -13,21 +13,15 @@
   >
 
   {{!-- Search results dropdown --}}
-  {{#ember-tether
-    target="#search-input"
-    targetAttachment="bottom left"
-    attachment="top left"
-    constraints=this._resultTetherConstraints
-    class="ds-dropdown-results"
-  }}
+  <EmberTether @target="#search-input" @targetAttachment="bottom left" @attachment="top left" @constraints={{this._resultTetherConstraints}} @class="ds-dropdown-results">
     {{#if this.showDropdown}}
       <div class="ds-suggestions ds-dropdown-menu">
-        {{#dropdown-header}}
+        <DropdownHeader>
           Search Results
-        {{/dropdown-header}}
+        </DropdownHeader>
 
         {{#each this.searchService.results as |result|}}
-          {{search-result result=result}}
+          <SearchResult @result={{result}} />
         {{else}}
           <div class="algolia-docsearch-suggestion">
             <div class="algolia-docsearch-suggestion--noresults">
@@ -47,5 +41,5 @@
         </div>
       </div>
     {{/if}}
-  {{/ember-tether}}
+  </EmberTether>
 {{/if}}

--- a/app/templates/components/chapter-links.hbs
+++ b/app/templates/components/chapter-links.hbs
@@ -1,10 +1,10 @@
 {{! template-lint-disable no-link-to-positional-params no-curly-component-invocation no-implicit-this }}
 {{#if this.page.previousPage}}
-  {{#link-to "version.show" this.page.previousPage.url class="previous-guide"}}{{this.page.previousPage.title}}{{/link-to}}
+  <LinkTo @route="version.show" @model={{this.page.previousPage.url}} class="previous-guide">{{this.page.previousPage.title}}</LinkTo>
 {{/if}}
 
 {{#if this.page.nextPage}}
-  {{#link-to "version.show" this.page.nextPage.url class="next-guide"}}
+  <LinkTo @route="version.show" @model={{this.page.nextPage.url}} class="next-guide">
     {{#if this.page.isLastPage}}
       We've finished covering {{this.page.currentSection.title}}. Next up: {{this.page.nextSection.title}} - {{this.page.nextPage.title}}
     {{else if this.page.nextIsFirstPage}}
@@ -12,5 +12,5 @@
     {{else}}
       {{this.page.nextPage.title}}
     {{/if}}
-  {{/link-to}}
+  </LinkTo>
 {{/if}}

--- a/app/templates/components/guides-article.hbs
+++ b/app/templates/components/guides-article.hbs
@@ -6,7 +6,7 @@
       <div><strong>Old Guides - </strong>You are viewing the guides for Ember {{this.version}}.</div>
     </div>
 
-    {{#link-to "version.show" "release" this.path class="es-button-secondary"}} VIEW {{this.currentVersion}} {{/link-to}}
+    <LinkTo @route="version.show" @models={{array "release" this.path}} class="es-button-secondary"> VIEW {{this.currentVersion}} </LinkTo>
   </div>
 {{/if}}
 
@@ -26,6 +26,6 @@
 </h1>
 <hr>
 
-{{markdown-to-html this.model.content extensions="showdown-section-groups"}}
+<MarkdownToHtml @markdown={{this.model.content}} @extensions="showdown-section-groups" />
 
-{{chapter-links pages=this.pages}}
+<ChapterLinks @pages={{this.pages}} />

--- a/app/templates/version/index.hbs
+++ b/app/templates/version/index.hbs
@@ -1,2 +1,2 @@
 {{!-- template-lint-disable no-curly-component-invocation no-implicit-this --}}
-{{guides-article model=this.model.content pages=this.model.pages path="index" version=this.model.version currentVersion=this.model.currentVersion}}
+<GuidesArticle @model={{this.model.content}} @pages={{this.model.pages}} @path="index" @version={{this.model.version}} @currentVersion={{this.model.currentVersion}} />

--- a/app/templates/version/show.hbs
+++ b/app/templates/version/show.hbs
@@ -1,2 +1,2 @@
 {{!-- template-lint-disable no-curly-component-invocation no-implicit-this --}}
-{{guides-article model=this.model.content pages=this.model.pages path=this.model.path version=this.model.version currentVersion=this.model.currentVersion}}
+<GuidesArticle @model={{this.model.content}} @pages={{this.model.pages}} @path={{this.model.path}} @version={{this.model.version}} @currentVersion={{this.model.currentVersion}} />


### PR DESCRIPTION
This fixes another one of our deprecations that happens around non AngleBracket `{{link-to}}` calls 👍 