### PR TITLE
Sidemenu styling

### DIFF
--- a/addon/styles/table-of-contents.css
+++ b/addon/styles/table-of-contents.css
@@ -1,6 +1,6 @@
 /* All the .es-sidebar styling should probably move to the ember-styleguide when we agree this is the right thing to do */
 .es-sidebar {
-  border-right: 1px solid var(--color-gray-700);
+  border-right: 2px solid var(--color-gray-300);
   padding: var(--spacing-4) var(--spacing-4) 0 0;
   margin: calc(-1 * var(--spacing-6)) 0 calc(-1 * var(--spacing-6));
 }


### PR DESCRIPTION
Fixes #127  The styling of the border next to the menu is now the same as the `hr`
![Screenshot 2023-04-07 at 15 23 52](https://user-images.githubusercontent.com/5811560/230616568-e637fefa-a168-4437-a785-52af50ba3f6f.png)
