### PR TITLE
Remove margin bottom from pencil

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -152,7 +152,6 @@ main {
 .edit-page:link,
 .edit-page:visited {
   background: none;
-  margin-bottom: var(--spacing-2);
 }
 
 .edit-icon {


### PR DESCRIPTION
With the change of the bottom margin of the header this margin was no longer necessary. 

**Before**
<img width="904" alt="Screenshot 2023-06-05 at 10 20 44" src="https://github.com/ember-learn/guidemaker-ember-template/assets/5811560/f9059485-aa38-4e3c-97ee-a4571c2921ee">

**After**
<img width="911" alt="Screenshot 2023-06-05 at 10 20 30" src="https://github.com/ember-learn/guidemaker-ember-template/assets/5811560/46e3a0d5-13da-43e7-b215-8deee9f11f98">
