### PR TITLE
add prefixHeaderId to on-this-page links

### DIFF
--- a/addon/components/on-this-page.hbs
+++ b/addon/components/on-this-page.hbs
@@ -5,7 +5,7 @@
     <ul>
       {{#each @toc as |toc|}}
         <li>
-          <a href="#{{toc.id}}">{{toc.text}}</a>
+          <a href="#{{this.headerPrefix}}{{toc.id}}">{{toc.text}}</a>
         </li>
       {{/each}}
     </ul>

--- a/addon/components/on-this-page.js
+++ b/addon/components/on-this-page.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component';
+import config from 'ember-get-config';
+
+export default class OnThisPageComponent extends Component {
+  headerPrefix = config?.showdown?.prefixHeaderId ?? '';
+}


### PR DESCRIPTION
In the main ember guides we use showdown config to set a prefix for the header ids so that we didn't break links when we migrated to use Guidemaker for the guides

https://github.com/ember-learn/guides-source/blob/master/config/environment.js#L42-L45

This config needs to be read (if it exists) and set as a prefix to the links in the on-this-page component 👍 