### PR TITLE
Revert "add prefixHeaderId to on-this-page links"

### DIFF
--- a/addon/components/on-this-page.hbs
+++ b/addon/components/on-this-page.hbs
@@ -5,7 +5,7 @@
     <ul>
       {{#each @toc as |toc|}}
         <li>
-          <a href="#{{this.headerPrefix}}{{toc.id}}">{{toc.text}}</a>
+          <a href="#{{toc.id}}">{{toc.text}}</a>
         </li>
       {{/each}}
     </ul>

--- a/addon/components/on-this-page.js
+++ b/addon/components/on-this-page.js
@@ -1,6 +1,0 @@
-import Component from '@glimmer/component';
-import config from 'ember-get-config';
-
-export default class OnThisPageComponent extends Component {
-  headerPrefix = config?.showdown?.prefixHeaderId ?? '';
-}


### PR DESCRIPTION
This reverts #154

Essentially it was a nice try to fix the problem but it didn't cover all use cases. The right thing to do was to use the showdown config defined in the environment to build the markdown that we use to find the links on the page with. 

This is the fix that we needed: https://github.com/empress/guidemaker/pull/92