### PR TITLE
chore: add some spacing between article and footer

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -81,6 +81,7 @@ main {
   gap: 3em;
   grid-template-columns: minmax(20ch, 80ch) 16em;
   padding-top: var(--spacing-4);
+  padding-bottom: var(--spacing-4);
   justify-content: center;
 }
 


### PR DESCRIPTION
Tiny PR to add some spacing between the article and the footer.

| Before | After |
| --- | --- |
| <img width="1017" alt="image" src="https://github.com/ember-learn/guidemaker-ember-template/assets/10243652/041c421a-3f74-48a4-9382-908195050e97"> | <img width="1000" alt="image" src="https://github.com/ember-learn/guidemaker-ember-template/assets/10243652/c38e53a4-142f-4458-9b55-32c163cf5559"> |