### PR TITLE
Sidebar styling tweaks

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -106,9 +106,10 @@ main {
     border: none;
     padding: var(--spacing-2);
     z-index: 1;
-    margin-top: var(--spacing-2);
     display: flex;
     flex-direction: row-reverse;
+    margin: var(--spacing-2) 0 0 0;
+    background: var(--color-white);
   }
 
   main .es-sidebar-toggle {

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -59,10 +59,6 @@ main {
   padding: 0;
 }
 
-.sidebar-container > .es-sidebar {
-  margin: 0;
-}
-
 .info-banner-wrapper {
   margin: var(--spacing-1);
   padding: var(--spacing-1);

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -103,7 +103,6 @@ main {
 /* TODO figure out how much of this media query needs to go into the styleguide */
 @media (max-width: 844px) {
   main .es-sidebar[aria-expanded="true"] {
-    border: none;
     padding: var(--spacing-2);
     z-index: 1;
     display: flex;

--- a/addon/styles/table-of-contents.css
+++ b/addon/styles/table-of-contents.css
@@ -59,3 +59,9 @@ li.toc-heading {
 li.toc-heading:first-child {
   margin-top: 0;
 }
+
+@media (max-width: 844px) {
+  .table-of-contents {
+    font-size: var(--font-size-lg);
+  }
+}

--- a/addon/styles/table-of-contents.css
+++ b/addon/styles/table-of-contents.css
@@ -8,13 +8,13 @@
 .table-of-contents {
   list-style-type: none;
   padding-left: 0;
-  font-size: var(--font-size-lg);
+  font-size: var(--font-size-base);
   font-weight: var(--font-weight-3);
 }
 
 .sub-table-of-contents {
   padding-left: var(--spacing-1);
-  font-size: var(--font-size-md);
+  font-size: var(--font-size-base);
   font-weight: var(--font-weight-2);
 }
 

--- a/addon/styles/table-of-contents.css
+++ b/addon/styles/table-of-contents.css
@@ -1,8 +1,8 @@
 /* All the .es-sidebar styling should probably move to the ember-styleguide when we agree this is the right thing to do */
 .es-sidebar {
-  border-right: 2px solid var(--color-gray-300);
-  padding: var(--spacing-4) var(--spacing-4) 0 0;
-  margin: calc(-1 * var(--spacing-6)) 0 calc(-1 * var(--spacing-6));
+  padding: var(--spacing-4) var(--spacing-4);
+  margin-left: calc(-1 * var(--spacing-4));
+  background-color: var(--color-gray-200);
 }
 
 .table-of-contents {


### PR DESCRIPTION
Thanks a bunch for the recent styling revamp! It's great to see the guides being aligned with the overall branding.

I've noticed I find scanning through the new TOC harder as the font size is huge. This PR reuses the base font size for the TOC. It also sets a background color to make an easier difference between TOC and the article content, now that there's three side-by-side content panels. (with the new "on this page" panel)

I didn't talk this change through with anyone, so feel free to shoot it down if undesired. Or provide feedback so I can further tweak it 😄 

| Before | After |
| --- | --- |
| <img width="1436" alt="image" src="https://github.com/ember-learn/guidemaker-ember-template/assets/10243652/0bb898cc-02a1-45a6-876c-96e258389df0"> | <img width="1436" alt="image" src="https://github.com/ember-learn/guidemaker-ember-template/assets/10243652/ca27a2ad-7815-4b11-b982-ffe95921ab7d"> |