### PR TITLE
Bumped e-showdown-prism dep to 4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "ember-get-config": "^2.1.1",
         "ember-href-to": "^5.0.0",
         "ember-power-select": "^6.0.0",
-        "ember-showdown-prism": "^4.2.0",
+        "ember-showdown-prism": "^4.4.0",
         "ember-styleguide": "^8.3.0",
         "ember-tether": "^2.0.1",
         "ember-truth-helpers": "^3.0.0"
@@ -20475,9 +20475,9 @@
       }
     },
     "node_modules/ember-showdown-prism": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ember-showdown-prism/-/ember-showdown-prism-4.2.0.tgz",
-      "integrity": "sha512-zAt7t4J8/ZE4hIw8PcOmRv5X2ZxgCQ0zuR4edVoURQsALsKMbtXsi6eqb7NogC1mg/0jPE8yEPcMUhVkQ9D9Pw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ember-showdown-prism/-/ember-showdown-prism-4.4.0.tgz",
+      "integrity": "sha512-RHBbw3ILNr5LDxOUWAPRpJAAUvp5RLD53yXMVrB1xVJTwTB2NT/igY+uFMGV8IRiRCS4S4PWghgkhy6nXSarEg==",
       "dependencies": {
         "broccoli-funnel": "^3.0.1",
         "ember-auto-import": "^2.6.3",
@@ -51280,9 +51280,9 @@
       }
     },
     "ember-showdown-prism": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ember-showdown-prism/-/ember-showdown-prism-4.2.0.tgz",
-      "integrity": "sha512-zAt7t4J8/ZE4hIw8PcOmRv5X2ZxgCQ0zuR4edVoURQsALsKMbtXsi6eqb7NogC1mg/0jPE8yEPcMUhVkQ9D9Pw==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ember-showdown-prism/-/ember-showdown-prism-4.4.0.tgz",
+      "integrity": "sha512-RHBbw3ILNr5LDxOUWAPRpJAAUvp5RLD53yXMVrB1xVJTwTB2NT/igY+uFMGV8IRiRCS4S4PWghgkhy6nXSarEg==",
       "requires": {
         "broccoli-funnel": "^3.0.1",
         "ember-auto-import": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-get-config": "^2.1.1",
     "ember-href-to": "^5.0.0",
     "ember-power-select": "^6.0.0",
-    "ember-showdown-prism": "^4.2.0",
+    "ember-showdown-prism": "^4.4.0",
     "ember-styleguide": "^8.3.0",
     "ember-tether": "^2.0.1",
     "ember-truth-helpers": "^3.0.0"

--- a/tests/dummy/guides/release/examples/syntax-highlighting.md
+++ b/tests/dummy/guides/release/examples/syntax-highlighting.md
@@ -5,6 +5,29 @@ You can do code blocks or `inline code in backticks`.
 mkdir super-rentals
 ```
 
+```json5 {data-filename=app/random.json}
+// This is an example of a json file with comments and trailing commas
+{ 
+  "name": "something", // A comment saying something about something 
+  "stuff": {
+    "another-name": "something else",
+  }
+  // See, we survived a trailing comma - huzzah
+}
+```
+
+```typescript {data-filename=app/router.ts}
+import EmberRouter from '@ember/routing/router';
+import config from './config/environment';
+
+export default class Router extends EmberRouter {
+  location = config.locationType;
+  rootURL = config.rootURL;
+}
+
+Router.map(function() {});
+```
+
 ```javascript {data-filename=app/router.js}
 import EmberRouter from '@ember/routing/router';
 import config from './config/environment';


### PR DESCRIPTION
A whole series of small PRs has the cumulative goal of making json5 support and any other kinds of source examples we need available to the guides.

*  `ember-showdown-prism` 4.4.0 has typescript and json5 support in its `ember-prism` settings.
*  empress/guidemaker PR#93, now in review, removes its override of the settings, so that the settings specified in `ember-showdown-prism` will take effect. 
* This PR causes the ember template to use the new version of ember-showdown-prism. 

To date, this change isn't using the new guidemaker, so it will need to be updated once more as soon as that change is released. It also needs typescript and json5 code samples in its test app, so that running the test app will test all three together. Then it can undergo final review.

Once all that is done, `guides-source` will then need to take the updated versions of both `guidemaker` and this template, and the knot the three addons have formed will finally be untangled.