### PR TITLE
deps: upgrade to ember-showdown-shiki

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "ember-get-config": "^2.1.1",
         "ember-href-to": "^5.0.0",
         "ember-power-select": "^6.0.0",
-        "ember-showdown-shiki": "^1.0.2",
+        "ember-showdown-shiki": "^1.0.3",
         "ember-styleguide": "^8.3.0",
         "ember-tether": "^2.0.1",
         "ember-truth-helpers": "^3.0.0",
@@ -22028,9 +22028,9 @@
       }
     },
     "node_modules/ember-showdown-shiki": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.0.2.tgz",
-      "integrity": "sha512-Fwym0bLVwSRZOIB4h0RTPomfHyDniAujZkbhSp2592Bc6EZsWr4+0KoA9kP7D+9bCqEvfGifZiWttgFGBNXzBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.0.3.tgz",
+      "integrity": "sha512-aK3nTSSL0K++xAT8ncIay8UFfPJsQDHJv61eyTJz/uTkIWejFKVOrVy+rtpQdkrp6/YV4vBgUuPl2GsHnpIJUw==",
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
         "@shikijs/transformers": "^v1.0.0-beta.0",
@@ -58541,9 +58541,9 @@
       }
     },
     "ember-showdown-shiki": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.0.2.tgz",
-      "integrity": "sha512-Fwym0bLVwSRZOIB4h0RTPomfHyDniAujZkbhSp2592Bc6EZsWr4+0KoA9kP7D+9bCqEvfGifZiWttgFGBNXzBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.0.3.tgz",
+      "integrity": "sha512-aK3nTSSL0K++xAT8ncIay8UFfPJsQDHJv61eyTJz/uTkIWejFKVOrVy+rtpQdkrp6/YV4vBgUuPl2GsHnpIJUw==",
       "requires": {
         "@embroider/addon-shim": "^1.8.7",
         "@shikijs/transformers": "^v1.0.0-beta.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "ember-get-config": "^2.1.1",
         "ember-href-to": "^5.0.0",
         "ember-power-select": "^6.0.0",
-        "ember-showdown-shikiji": "^0.3.0",
+        "ember-showdown-shiki": "^1.0.0",
         "ember-styleguide": "^8.3.0",
         "ember-tether": "^2.0.1",
         "ember-truth-helpers": "^3.0.0",
@@ -6507,6 +6507,19 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@shikijs/core": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.0.0-beta.3.tgz",
+      "integrity": "sha512-SCwPom2Wn8XxNlEeqdzycU93SKgzYeVsedjqDsgZaz4XiiPpZUzlHt2NAEQTwTnPcHNZapZ6vbkwJ8P11ggL3Q=="
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.0.0-beta.3.tgz",
+      "integrity": "sha512-ASQQQqxW4dANxMGw4yGkTjtMSsUaRhImv/lzJEdfJ3/eP8TVlVYnohOFQVgpLjBBYGy9P0l0oKrlbjiGosTJ/Q==",
+      "dependencies": {
+        "shiki": "1.0.0-beta.3"
       }
     },
     "node_modules/@simple-dom/document": {
@@ -22014,18 +22027,17 @@
         "node": "10.* || >= 12"
       }
     },
-    "node_modules/ember-showdown-shikiji": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ember-showdown-shikiji/-/ember-showdown-shikiji-0.3.0.tgz",
-      "integrity": "sha512-QR4/qgwvoyQ2b5bt1eeSBuaqe1F5wLyGgZ5sHqGmgN08ogtYGVBlsTFp5XxRTKw5B0w00IoV7r4d1J0ohRbeLA==",
+    "node_modules/ember-showdown-shiki": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.0.0.tgz",
+      "integrity": "sha512-8XIT8Ke4UU9jc664KG/5GriFzYMiDvHSw5fiO+7oJPSLF+7bhRC8sbGkEBkr4rD37vmiJV1m0GY9O/iDc+KyXA==",
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
+        "@shikijs/transformers": "^v1.0.0-beta.0",
         "decorator-transforms": "^1.0.1",
-        "shikiji": "^0.9.19",
-        "shikiji-transformers": "^0.9.19"
+        "shiki": "^v1.0.0-beta.0"
       },
       "peerDependencies": {
-        "ember-styleguide": "^8.3.0",
         "showdown": ">1.0.0"
       }
     },
@@ -37477,25 +37489,12 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
-    "node_modules/shikiji": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.9.19.tgz",
-      "integrity": "sha512-Kw2NHWktdcdypCj1GkKpXH4o6Vxz8B8TykPlPuLHOGSV8VkhoCLcFOH4k19K4LXAQYRQmxg+0X/eM+m2sLhAkg==",
+    "node_modules/shiki": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.0.0-beta.3.tgz",
+      "integrity": "sha512-z7cHTNSSvwGx2DfeLwjSNLo+HcVxifgNIzLm6Ye52eXcIwNHXT0wHbhy7FDOKSKveuEHBwt9opfj3Hoc8LE1Yg==",
       "dependencies": {
-        "shikiji-core": "0.9.19"
-      }
-    },
-    "node_modules/shikiji-core": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/shikiji-core/-/shikiji-core-0.9.19.tgz",
-      "integrity": "sha512-AFJu/vcNT21t0e6YrfadZ+9q86gvPum6iywRyt1OtIPjPFe25RQnYJyxHQPMLKCCWA992TPxmEmbNcOZCAJclw=="
-    },
-    "node_modules/shikiji-transformers": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/shikiji-transformers/-/shikiji-transformers-0.9.19.tgz",
-      "integrity": "sha512-lGLI7Z8frQrIBbhZ74/eiJtxMoCQRbpaHEB+gcfvdIy+ZFaAtXncJGnc52932/UET+Y4GyKtwwC/vjWUCp+c/Q==",
-      "dependencies": {
-        "shikiji": "0.9.19"
+        "@shikijs/core": "1.0.0-beta.3"
       }
     },
     "node_modules/showdown": {
@@ -46199,6 +46198,19 @@
             "isexe": "^2.0.0"
           }
         }
+      }
+    },
+    "@shikijs/core": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.0.0-beta.3.tgz",
+      "integrity": "sha512-SCwPom2Wn8XxNlEeqdzycU93SKgzYeVsedjqDsgZaz4XiiPpZUzlHt2NAEQTwTnPcHNZapZ6vbkwJ8P11ggL3Q=="
+    },
+    "@shikijs/transformers": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-1.0.0-beta.3.tgz",
+      "integrity": "sha512-ASQQQqxW4dANxMGw4yGkTjtMSsUaRhImv/lzJEdfJ3/eP8TVlVYnohOFQVgpLjBBYGy9P0l0oKrlbjiGosTJ/Q==",
+      "requires": {
+        "shiki": "1.0.0-beta.3"
       }
     },
     "@simple-dom/document": {
@@ -58528,15 +58540,15 @@
         "ember-decorators-polyfill": "^1.1.5"
       }
     },
-    "ember-showdown-shikiji": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/ember-showdown-shikiji/-/ember-showdown-shikiji-0.3.0.tgz",
-      "integrity": "sha512-QR4/qgwvoyQ2b5bt1eeSBuaqe1F5wLyGgZ5sHqGmgN08ogtYGVBlsTFp5XxRTKw5B0w00IoV7r4d1J0ohRbeLA==",
+    "ember-showdown-shiki": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.0.0.tgz",
+      "integrity": "sha512-8XIT8Ke4UU9jc664KG/5GriFzYMiDvHSw5fiO+7oJPSLF+7bhRC8sbGkEBkr4rD37vmiJV1m0GY9O/iDc+KyXA==",
       "requires": {
         "@embroider/addon-shim": "^1.8.7",
+        "@shikijs/transformers": "^v1.0.0-beta.0",
         "decorator-transforms": "^1.0.1",
-        "shikiji": "^0.9.19",
-        "shikiji-transformers": "^0.9.19"
+        "shiki": "^v1.0.0-beta.0"
       }
     },
     "ember-source": {
@@ -70356,25 +70368,12 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
-    "shikiji": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/shikiji/-/shikiji-0.9.19.tgz",
-      "integrity": "sha512-Kw2NHWktdcdypCj1GkKpXH4o6Vxz8B8TykPlPuLHOGSV8VkhoCLcFOH4k19K4LXAQYRQmxg+0X/eM+m2sLhAkg==",
+    "shiki": {
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.0.0-beta.3.tgz",
+      "integrity": "sha512-z7cHTNSSvwGx2DfeLwjSNLo+HcVxifgNIzLm6Ye52eXcIwNHXT0wHbhy7FDOKSKveuEHBwt9opfj3Hoc8LE1Yg==",
       "requires": {
-        "shikiji-core": "0.9.19"
-      }
-    },
-    "shikiji-core": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/shikiji-core/-/shikiji-core-0.9.19.tgz",
-      "integrity": "sha512-AFJu/vcNT21t0e6YrfadZ+9q86gvPum6iywRyt1OtIPjPFe25RQnYJyxHQPMLKCCWA992TPxmEmbNcOZCAJclw=="
-    },
-    "shikiji-transformers": {
-      "version": "0.9.19",
-      "resolved": "https://registry.npmjs.org/shikiji-transformers/-/shikiji-transformers-0.9.19.tgz",
-      "integrity": "sha512-lGLI7Z8frQrIBbhZ74/eiJtxMoCQRbpaHEB+gcfvdIy+ZFaAtXncJGnc52932/UET+Y4GyKtwwC/vjWUCp+c/Q==",
-      "requires": {
-        "shikiji": "0.9.19"
+        "@shikijs/core": "1.0.0-beta.3"
       }
     },
     "showdown": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "ember-get-config": "^2.1.1",
         "ember-href-to": "^5.0.0",
         "ember-power-select": "^6.0.0",
-        "ember-showdown-shiki": "^1.0.0",
+        "ember-showdown-shiki": "^1.0.2",
         "ember-styleguide": "^8.3.0",
         "ember-tether": "^2.0.1",
         "ember-truth-helpers": "^3.0.0",
@@ -22028,9 +22028,9 @@
       }
     },
     "node_modules/ember-showdown-shiki": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.0.0.tgz",
-      "integrity": "sha512-8XIT8Ke4UU9jc664KG/5GriFzYMiDvHSw5fiO+7oJPSLF+7bhRC8sbGkEBkr4rD37vmiJV1m0GY9O/iDc+KyXA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.0.2.tgz",
+      "integrity": "sha512-Fwym0bLVwSRZOIB4h0RTPomfHyDniAujZkbhSp2592Bc6EZsWr4+0KoA9kP7D+9bCqEvfGifZiWttgFGBNXzBw==",
       "dependencies": {
         "@embroider/addon-shim": "^1.8.7",
         "@shikijs/transformers": "^v1.0.0-beta.0",
@@ -58541,9 +58541,9 @@
       }
     },
     "ember-showdown-shiki": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.0.0.tgz",
-      "integrity": "sha512-8XIT8Ke4UU9jc664KG/5GriFzYMiDvHSw5fiO+7oJPSLF+7bhRC8sbGkEBkr4rD37vmiJV1m0GY9O/iDc+KyXA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ember-showdown-shiki/-/ember-showdown-shiki-1.0.2.tgz",
+      "integrity": "sha512-Fwym0bLVwSRZOIB4h0RTPomfHyDniAujZkbhSp2592Bc6EZsWr4+0KoA9kP7D+9bCqEvfGifZiWttgFGBNXzBw==",
       "requires": {
         "@embroider/addon-shim": "^1.8.7",
         "@shikijs/transformers": "^v1.0.0-beta.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-get-config": "^2.1.1",
     "ember-href-to": "^5.0.0",
     "ember-power-select": "^6.0.0",
-    "ember-showdown-shikiji": "^0.3.0",
+    "ember-showdown-shiki": "^1.0.0",
     "ember-styleguide": "^8.3.0",
     "ember-tether": "^2.0.1",
     "ember-truth-helpers": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-get-config": "^2.1.1",
     "ember-href-to": "^5.0.0",
     "ember-power-select": "^6.0.0",
-    "ember-showdown-shiki": "^1.0.2",
+    "ember-showdown-shiki": "^1.0.3",
     "ember-styleguide": "^8.3.0",
     "ember-tether": "^2.0.1",
     "ember-truth-helpers": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-get-config": "^2.1.1",
     "ember-href-to": "^5.0.0",
     "ember-power-select": "^6.0.0",
-    "ember-showdown-shiki": "^1.0.0",
+    "ember-showdown-shiki": "^1.0.2",
     "ember-styleguide": "^8.3.0",
     "ember-tether": "^2.0.1",
     "ember-truth-helpers": "^3.0.0",

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -36,7 +36,7 @@ module.exports = function (environment) {
       indexName: 'ember-guides'
     },
 
-    'ember-showdown-shikiji': {
+    'ember-showdown-shiki': {
       languages: [
         'bash',
         'css',


### PR DESCRIPTION
This switches to the latest stable release of [`ember-showdown-shiki`](https://github.com/IgnaceMaes/ember-showdown-shiki):

- Rename from `shikiji` to `shiki`
- And contains some bug fixes