### PR TITLE
style: update "on this page" to only show headers up until level 3 and indent

### DIFF
--- a/addon/components/on-this-page.hbs
+++ b/addon/components/on-this-page.hbs
@@ -4,9 +4,11 @@
     <hr>
     <ul>
       {{#each @toc as |toc|}}
-        <li>
-          <a href="#{{toc.id}}">{{toc.text}}</a>
-        </li>
+       {{#if (or (eq toc.depth '1') (eq toc.depth '2') (eq toc.depth '3'))}}
+          <li>
+            <a href="#{{toc.id}}" class="on-this-page-depth-{{toc.depth}}">{{toc.text}}</a>
+          </li>
+        {{/if}}
       {{/each}}
     </ul>
     {{yield}}

--- a/addon/styles/on-this-page.css
+++ b/addon/styles/on-this-page.css
@@ -34,6 +34,6 @@ main .on-this-page-wrapper a:hover {
   color: var(--color-gray-800);
 }
 
-.on-this-page-depth-3 {
+main .on-this-page-wrapper a.on-this-page-depth-3 {
   padding-left: var(--spacing-4);
 }

--- a/addon/styles/on-this-page.css
+++ b/addon/styles/on-this-page.css
@@ -5,7 +5,6 @@
 .on-this-page-wrapper ul {
   list-style: none;
   padding: 0;
-  padding-left: var(--spacing-2);
   margin-top: var(--spacing-2);
   border-left: 2px solid var(--color-gray-300);
 }
@@ -28,6 +27,7 @@ main .on-this-page-wrapper a {
   padding-bottom: 2px;
   display: block;
   transition: color 0.2s ease;
+  padding-left: var(--spacing-2);
 }
 
 main .on-this-page-wrapper a:hover {
@@ -35,5 +35,5 @@ main .on-this-page-wrapper a:hover {
 }
 
 .on-this-page-depth-3 {
-  padding-left: var(--spacing-2);
+  padding-left: var(--spacing-4);
 }

--- a/addon/styles/on-this-page.css
+++ b/addon/styles/on-this-page.css
@@ -24,11 +24,16 @@ main .on-this-page-wrapper a {
   text-decoration: none;
   color: var(--color-gray-600);
   background: none;
-  padding: 2px 0;
+  padding-top: 2px;
+  padding-bottom: 2px;
   display: block;
   transition: color 0.2s ease;
 }
 
 main .on-this-page-wrapper a:hover {
   color: var(--color-gray-800);
+}
+
+.on-this-page-depth-3 {
+  padding-left: var(--spacing-2);
 }

--- a/tests/integration/components/on-this-page-test.js
+++ b/tests/integration/components/on-this-page-test.js
@@ -8,12 +8,28 @@ module('Integration | Component | on-this-page', function (hooks) {
 
   test('it renders', async function (assert) {
     this.set('toc', [
-      { text: 'Introduction', id: '1' },
-      { text: 'Follow-up item', id: '2' },
+      { text: 'Introduction', id: '1', depth: '1' },
+      { text: 'Follow-up item', id: '2', depth: '2' },
     ]);
 
     await render(hbs`<OnThisPage @toc={{this.toc}} />`);
 
     assert.dom(this.element).containsText('On this page');
+  });
+
+  test('only renders headings up until depth 3', async function (assert) {
+    this.set('toc', [
+      { text: 'h1', id: '1', depth: '1' },
+      { text: 'h2', id: '2', depth: '2' },
+      { text: 'h3', id: '3', depth: '3' },
+      { text: 'h4', id: '4', depth: '4' },
+    ]);
+
+    await render(hbs`<OnThisPage @toc={{this.toc}} />`);
+
+    assert.dom(this.element).containsText('h1');
+    assert.dom(this.element).containsText('h1');
+    assert.dom(this.element).containsText('h1');
+    assert.dom(this.element).doesNotContainText('h4');
   });
 });


### PR DESCRIPTION
Implements https://github.com/ember-learn/guidemaker-ember-template/issues/179

- Only shows h1, h2, and h3 in the "on this page" section
- Indents h3 levels with left padding
  - h2 not indented as I believe it should be the base and h1 should be kept for the title only (see related fix: https://github.com/ember-learn/guides-source/pull/2012)

| Before | After |
| --- | --- |
|  <img width="239" src="https://github.com/ember-learn/guidemaker-ember-template/assets/10243652/72f39e03-00f6-440b-b993-131acdad45d3"> | <img width="248" src="https://github.com/ember-learn/guidemaker-ember-template/assets/10243652/3ceaa8b0-e4b2-49b3-b4ca-3147f60de844"> |

To be fair, this example doesn't properly showcase the real difference, and a real content page would be better suited to test.

EDIT: test using the [Template Tag Format content](https://guides.emberjs.com/release/components/template-tag-format/):

| Before | After |
| --- | --- |
| <img width="340" src="https://github.com/ember-learn/guidemaker-ember-template/assets/10243652/f78b669c-8b8d-42c3-9ef6-c1b5d4dbc239"> | <img width="309"  src="https://github.com/ember-learn/guidemaker-ember-template/assets/10243652/c218bbb0-3bb1-4081-80ac-dd9e18693a9f"> |
