### PR TITLE
Transform guides-article to glimmer component

### DIFF
--- a/guidemaker-ember-template/.prettierrc.cjs
+++ b/guidemaker-ember-template/.prettierrc.cjs
@@ -3,4 +3,18 @@
 module.exports = {
   plugins: ['prettier-plugin-ember-template-tag'],
   singleQuote: true,
+  overrides: [
+    {
+      files: '*.{js,ts}',
+      options: {
+        singleQuote: true,
+      },
+    },
+    {
+      files: '*.hbs',
+      options: {
+        singleQuote: false,
+      },
+    },
+  ],
 };

--- a/guidemaker-ember-template/src/components/guides-article.hbs
+++ b/guidemaker-ember-template/src/components/guides-article.hbs
@@ -1,37 +1,64 @@
 {{! template-lint-disable no-negated-condition no-link-to-positional-params link-rel-noopener no-curly-component-invocation no-implicit-this }}
-<div class='guides-article-wrapper'>
-  <div class='guides-article-content'>
+<div class="guides-article-wrapper">
+  <div class="guides-article-content">
     {{#if (not (eq this.version this.currentVersion))}}
-      <div class='old-version-warning'>
-        <div class='old-version-warning-text'>
-          <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="exclamation-circle" class="warning-icon" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"></path></svg>
-          <div><strong>Old Guides - </strong>You are viewing the guides for
-            Ember
-            {{this.version}}.</div>
+      <div class="old-version-warning">
+        <div class="old-version-warning-text">
+          <svg
+            aria-hidden="true"
+            focusable="false"
+            data-prefix="fas"
+            data-icon="exclamation-circle"
+            class="warning-icon"
+            role="img"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 512 512"
+          >
+            <path
+              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+            ></path>
+          </svg>
+          <div>
+            <strong>Old Guides - </strong>You are viewing the guides for Ember
+            {{this.version}}.
+          </div>
         </div>
 
         <LinkTo
-          @route='version.show'
-          @models={{array 'release' this.path}}
-          class='es-button-secondary old-version-button'
-        > Go to {{this.currentVersion}} </LinkTo>
+          @route="version.show"
+          @models={{array "release" this.path}}
+          class="es-button-secondary old-version-button"
+        >
+          Go to {{this.currentVersion}}
+        </LinkTo>
       </div>
     {{/if}}
 
-    <div class='article-title'>
+    <div class="article-title">
       <h1>
         {{this.page.currentPage.title}}
       </h1>
 
       {{#if this.guidemaker.sourceRepo}}
         <a
-          href="{{this.guidemaker.sourceRepo}}/edit/{{or this.guidemaker.sourceBranch "master"}}/guides/{{this.editVersion}}{{this.model.id}}.md"
-          target='_blank'
-          class='edit-page'
-          rel='noopener'
+          href="{{this.guidemaker.sourceRepo}}/edit/{{or
+            this.guidemaker.sourceBranch
+            'master'
+          }}/guides/{{this.editVersion}}{{this.model.id}}.md"
+          target="_blank"
+          class="edit-page"
+          rel="noopener"
         >
-          {{!-- ! Font Awesome Free 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc. --}}
-          <svg class="edit-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M362.7 19.3L314.3 67.7 444.3 197.7l48.4-48.4c25-25 25-65.5 0-90.5L453.3 19.3c-25-25-65.5-25-90.5 0zm-71 71L58.6 323.5c-10.4 10.4-18 23.3-22.2 37.4L1 481.2C-1.5 489.7 .8 498.8 7 505s15.3 8.5 23.7 6.1l120.3-35.4c14.1-4.2 27-11.8 37.4-22.2L421.7 220.3 291.7 90.3z"/></svg>
+          {{! ! Font Awesome Free 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc. }}
+          <svg
+            class="edit-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 512 512"
+          >
+            <path
+              d="M362.7 19.3L314.3 67.7 444.3 197.7l48.4-48.4c25-25 25-65.5 0-90.5L453.3 19.3c-25-25-65.5-25-90.5 0zm-71 71L58.6 323.5c-10.4 10.4-18 23.3-22.2 37.4L1 481.2C-1.5 489.7 .8 498.8 7 505s15.3 8.5 23.7 6.1l120.3-35.4c14.1-4.2 27-11.8 37.4-22.2L421.7 220.3 291.7 90.3z"
+            />
+          </svg>
         </a>
       {{/if}}
     </div>
@@ -39,12 +66,12 @@
 
     <MarkdownToHtml
       @markdown={{this.model.content}}
-      @extensions='showdown-section-groups header-links'
+      @extensions="showdown-section-groups header-links"
     />
 
     <ChapterLinks @pages={{this.pages}} />
   </div>
-  <div class='guides-article-toc'>
+  <div class="guides-article-toc">
     <OnThisPage @toc={{@model.toc}} />
   </div>
 </div>

--- a/guidemaker-ember-template/src/components/guides-article.hbs
+++ b/guidemaker-ember-template/src/components/guides-article.hbs
@@ -1,77 +1,78 @@
-{{! template-lint-disable no-negated-condition no-link-to-positional-params link-rel-noopener no-curly-component-invocation no-implicit-this }}
-<div class="guides-article-wrapper">
-  <div class="guides-article-content">
-    {{#if (not (eq this.version this.currentVersion))}}
-      <div class="old-version-warning">
-        <div class="old-version-warning-text">
-          <svg
-            aria-hidden="true"
-            focusable="false"
-            data-prefix="fas"
-            data-icon="exclamation-circle"
-            class="warning-icon"
-            role="img"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 512 512"
-          >
-            <path
-              d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-            ></path>
-          </svg>
-          <div>
-            <strong>Old Guides - </strong>You are viewing the guides for Ember
-            {{this.version}}.
+<article class="chapter" ...attributes>
+  <div class="guides-article-wrapper">
+    <div class="guides-article-content">
+      {{#unless (eq @version @currentVersion)}}
+        <div class="old-version-warning">
+          <div class="old-version-warning-text">
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              data-prefix="fas"
+              data-icon="exclamation-circle"
+              class="warning-icon"
+              role="img"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+              ></path>
+            </svg>
+            <div>
+              <strong>Old Guides - </strong>You are viewing the guides for Ember
+              {{@version}}.
+            </div>
           </div>
-        </div>
 
-        <LinkTo
-          @route="version.show"
-          @models={{array "release" this.path}}
-          class="es-button-secondary old-version-button"
-        >
-          Go to {{this.currentVersion}}
-        </LinkTo>
-      </div>
-    {{/if}}
-
-    <div class="article-title">
-      <h1>
-        {{this.page.currentPage.title}}
-      </h1>
-
-      {{#if this.guidemaker.sourceRepo}}
-        <a
-          href="{{this.guidemaker.sourceRepo}}/edit/{{or
-            this.guidemaker.sourceBranch
-            'master'
-          }}/guides/{{this.editVersion}}{{this.model.id}}.md"
-          target="_blank"
-          class="edit-page"
-          rel="noopener"
-        >
-          {{! ! Font Awesome Free 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc. }}
-          <svg
-            class="edit-icon"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 512 512"
+          <LinkTo
+            @route="version.show"
+            @models={{array "release" @path}}
+            class="es-button-secondary old-version-button"
           >
-            <path
-              d="M362.7 19.3L314.3 67.7 444.3 197.7l48.4-48.4c25-25 25-65.5 0-90.5L453.3 19.3c-25-25-65.5-25-90.5 0zm-71 71L58.6 323.5c-10.4 10.4-18 23.3-22.2 37.4L1 481.2C-1.5 489.7 .8 498.8 7 505s15.3 8.5 23.7 6.1l120.3-35.4c14.1-4.2 27-11.8 37.4-22.2L421.7 220.3 291.7 90.3z"
-            />
-          </svg>
-        </a>
-      {{/if}}
+            Go to {{@currentVersion}}
+          </LinkTo>
+        </div>
+      {{/unless}}
+
+      <div class="article-title">
+        <h1>
+          {{this.page.currentPage.title}}
+        </h1>
+
+        {{#if this.guidemaker.sourceRepo}}
+          <a
+            href="{{this.guidemaker.sourceRepo}}/edit/{{or
+              this.guidemaker.sourceBranch
+              'master'
+            }}/guides/{{this.editVersion}}{{@model.id}}.md"
+            target="_blank"
+            class="edit-page"
+            rel="noopener noreferrer"
+          >
+            {{! ! Font Awesome Free 6.2.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) Copyright 2022 Fonticons, Inc. }}
+            <svg
+              class="edit-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M362.7 19.3L314.3 67.7 444.3 197.7l48.4-48.4c25-25 25-65.5 0-90.5L453.3 19.3c-25-25-65.5-25-90.5 0zm-71 71L58.6 323.5c-10.4 10.4-18 23.3-22.2 37.4L1 481.2C-1.5 489.7 .8 498.8 7 505s15.3 8.5 23.7 6.1l120.3-35.4c14.1-4.2 27-11.8 37.4-22.2L421.7 220.3 291.7 90.3z"
+              />
+            </svg>
+          </a>
+        {{/if}}
+      </div>
+      <hr />
+
+      <MarkdownToHtml
+        @markdown={{@model.content}}
+        @extensions="showdown-section-groups header-links"
+      />
+
+      <ChapterLinks @pages={{@pages}} />
     </div>
-    <hr />
-
-    <MarkdownToHtml
-      @markdown={{this.model.content}}
-      @extensions="showdown-section-groups header-links"
-    />
-
-    <ChapterLinks @pages={{this.pages}} />
+    <div class="guides-article-toc">
+      <OnThisPage @toc={{@model.toc}} />
+    </div>
   </div>
-  <div class="guides-article-toc">
-    <OnThisPage @toc={{@model.toc}} />
-  </div>
-</div>
+</article>

--- a/guidemaker-ember-template/src/components/guides-article.js
+++ b/guidemaker-ember-template/src/components/guides-article.js
@@ -4,8 +4,8 @@ import { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 
 function wrap(el, wrapper) {
-    el.parentNode.insertBefore(wrapper, el);
-    wrapper.appendChild(el);
+  el.parentNode.insertBefore(wrapper, el);
+  wrapper.appendChild(el);
 }
 
 export default Component.extend({
@@ -13,13 +13,13 @@ export default Component.extend({
   classNames: 'chapter',
   page: service(),
   guidemaker: service(),
-  editVersion: computed('version', 'currentVersion', function() {
-    if(this.page.currentVersion === 'release') {
+  editVersion: computed('version', 'currentVersion', function () {
+    if (this.page.currentVersion === 'release') {
       return '';
     }
 
-    if(this.version === this.currentVersion) {
-      return 'release/'
+    if (this.version === this.currentVersion) {
+      return 'release/';
     }
 
     return `${this.page.currentVersion}/`;

--- a/guidemaker-ember-template/src/components/guides-article.js
+++ b/guidemaker-ember-template/src/components/guides-article.js
@@ -1,27 +1,19 @@
-/* eslint-disable ember/no-classic-components, no-unused-vars, prettier/prettier, ember/no-classic-classes, ember/require-tagless-components, ember/require-computed-property-dependencies */
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
 
-function wrap(el, wrapper) {
-  el.parentNode.insertBefore(wrapper, el);
-  wrapper.appendChild(el);
-}
+export default class GuidesArticleComponent extends Component {
+  @service page;
+  @service guidemaker;
 
-export default Component.extend({
-  tagName: 'article',
-  classNames: 'chapter',
-  page: service(),
-  guidemaker: service(),
-  editVersion: computed('version', 'currentVersion', function () {
+  get editVersion() {
     if (this.page.currentVersion === 'release') {
       return '';
     }
 
-    if (this.version === this.currentVersion) {
+    if (this.args.version === this.args.currentVersion) {
       return 'release/';
     }
 
     return `${this.page.currentVersion}/`;
-  }),
-});
+  }
+}

--- a/guidemaker-ember-template/src/templates/version/index.gjs
+++ b/guidemaker-ember-template/src/templates/version/index.gjs
@@ -3,6 +3,11 @@ import RouteTemplate from 'ember-route-template';
 import GuidesArticle from '../../components/guides-article';
 
 export default RouteTemplate(<template>
-{{!-- template-lint-disable no-curly-component-invocation no-implicit-this --}}
-<GuidesArticle @model={{@controller.model.content}} @pages={{@controller.model.pages}} @path="index" @version={{@controller.model.version}} @currentVersion={{@controller.model.currentVersion}} />
+  <GuidesArticle
+    @model={{@controller.model.content}}
+    @pages={{@controller.model.pages}}
+    @path='index'
+    @version={{@controller.model.version}}
+    @currentVersion={{@controller.model.currentVersion}}
+  />
 </template>);

--- a/guidemaker-ember-template/src/templates/version/show.gjs
+++ b/guidemaker-ember-template/src/templates/version/show.gjs
@@ -3,6 +3,11 @@ import RouteTemplate from 'ember-route-template';
 import GuidesArticle from '../../components/guides-article';
 
 export default RouteTemplate(<template>
-{{!-- template-lint-disable no-curly-component-invocation no-implicit-this --}}
-<GuidesArticle @model={{@controller.model.content}} @pages={{@controller.model.pages}} @path={{@controller.model.path}} @version={{@controller.model.version}} @currentVersion={{@controller.model.currentVersion}} />
+  <GuidesArticle
+    @model={{@controller.model.content}}
+    @pages={{@controller.model.pages}}
+    @path={{@controller.model.path}}
+    @version={{@controller.model.version}}
+    @currentVersion={{@controller.model.currentVersion}}
+  />
 </template>);

--- a/test-app/tests/integration/components/guides-article-test.js
+++ b/test-app/tests/integration/components/guides-article-test.js
@@ -1,0 +1,101 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+
+// Stub page service
+class PageStub extends Service {
+  currentVersion = 'v1.0.0';
+  currentPage = {
+    title: 'This is the current page title',
+  };
+}
+
+module('Integration | Component | guides-article', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders the component', async function (assert) {
+    await render(hbs`
+      <GuidesArticle />
+    `);
+
+    assert.dom('.article-title').exists();
+    assert.dom('.guides-article-toc').exists();
+  });
+
+  test('it does not show the version warning if the current version is the selected version', async function (assert) {
+    this.version = 'v1.0.0';
+    this.currentVersion = 'v1.0.0';
+
+    await render(hbs`
+      <GuidesArticle @version={{this.version}} @currentVersion={{this.currentVersion}}/>
+    `);
+
+    assert.dom('.old-version-warning').doesNotExist();
+  });
+
+  test('it show the version warning if the selected version is not the current version', async function (assert) {
+    this.version = 'v1.0.0';
+    this.currentVersion = 'v2.0.0';
+
+    await render(hbs`
+      <GuidesArticle @version={{this.version}} @currentVersion={{this.currentVersion}}/>
+    `);
+
+    assert.dom('.old-version-warning').exists();
+    assert
+      .dom('.old-version-warning')
+      .hasText(
+        'Old Guides - You are viewing the guides for Ember v1.0.0. Go to v2.0.0',
+      );
+  });
+
+  test('it show the correct page title', async function (assert) {
+    this.owner.register('service:page', PageStub);
+
+    await render(hbs`
+      <GuidesArticle />
+    `);
+
+    assert.dom('.article-title').hasText('This is the current page title');
+  });
+
+  test('it renders the edit link for the current release', async function (assert) {
+    this.owner.register('service:page', PageStub);
+
+    this.model = {
+      id: 'model-id',
+    };
+
+    await render(hbs`
+      <GuidesArticle @model={{this.model}} />
+    `);
+
+    assert
+      .dom('.edit-page')
+      .hasProperty(
+        'href',
+        'https://github.com/ember-learn/guidemaker-ember-template/edit/master/guides/release/model-id.md',
+      );
+  });
+
+  test('it renders the edit link for the selected version', async function (assert) {
+    this.owner.register('service:page', PageStub);
+
+    this.model = {
+      id: 'model-id',
+    };
+
+    await render(hbs`
+      <GuidesArticle @model={{this.model}} @version="v1.0.0" />
+    `);
+
+    assert
+      .dom('.edit-page')
+      .hasProperty(
+        'href',
+        'https://github.com/ember-learn/guidemaker-ember-template/edit/master/guides/v1.0.0/model-id.md',
+      );
+  });
+});


### PR DESCRIPTION
For better readability, I have only formatted the the code in the first commit. I would recommend to ignore whitespaces.