### PR TITLE
Transform chapter-links to glimmer component

### DIFF
--- a/guidemaker-ember-template/src/components/chapter-links.hbs
+++ b/guidemaker-ember-template/src/components/chapter-links.hbs
@@ -19,7 +19,6 @@
         @model={{this.page.nextPage.url}}
         class="next-guide"
       >
-      {{log this.page.nextPage}}
         {{#if this.page.isLastPage}}
           We've finished covering
           {{this.page.currentSection.title}}. Next up:

--- a/guidemaker-ember-template/src/components/chapter-links.hbs
+++ b/guidemaker-ember-template/src/components/chapter-links.hbs
@@ -1,18 +1,37 @@
 {{! template-lint-disable no-link-to-positional-params no-curly-component-invocation no-implicit-this }}
-<EsPagination @showPrevious={{this.page.previousPage}} @showNext={{this.page.nextPage}}>
-   <:previous>
-    <LinkTo @route="version.show" @model={{this.page.previousPage.url}} class="previous-guide">{{this.page.previousPage.title}}</LinkTo>
-   </:previous>
+<EsPagination
+  @showPrevious={{this.page.previousPage}}
+  @showNext={{this.page.nextPage}}
+>
+  <:previous>
+    <LinkTo
+      @route="version.show"
+      @model={{this.page.previousPage.url}}
+      class="previous-guide"
+    >
+      {{this.page.previousPage.title}}
+    </LinkTo>
+  </:previous>
 
-    <:next>
-      <LinkTo @route="version.show" @model={{this.page.nextPage.url}} class="next-guide">
-        {{#if this.page.isLastPage}}
-          We've finished covering {{this.page.currentSection.title}}. Next up: {{this.page.nextSection.title}} - {{this.page.nextPage.title}}
-        {{else if this.page.nextIsFirstPage}}
-          {{this.page.nextSection.title}} - {{this.page.nextPage.title}}
-        {{else}}
-          {{this.page.nextPage.title}}
-        {{/if}}
-      </LinkTo>
-    </:next>
+  <:next>
+    <LinkTo
+      @route="version.show"
+      @model={{this.page.nextPage.url}}
+      class="next-guide"
+    >
+      {{#if this.page.isLastPage}}
+        We've finished covering
+        {{this.page.currentSection.title}}. Next up:
+        {{this.page.nextSection.title}}
+        -
+        {{this.page.nextPage.title}}
+      {{else if this.page.nextIsFirstPage}}
+        {{this.page.nextSection.title}}
+        -
+        {{this.page.nextPage.title}}
+      {{else}}
+        {{this.page.nextPage.title}}
+      {{/if}}
+    </LinkTo>
+  </:next>
 </EsPagination>

--- a/guidemaker-ember-template/src/components/chapter-links.hbs
+++ b/guidemaker-ember-template/src/components/chapter-links.hbs
@@ -1,37 +1,39 @@
-{{! template-lint-disable no-link-to-positional-params no-curly-component-invocation no-implicit-this }}
-<EsPagination
-  @showPrevious={{this.page.previousPage}}
-  @showNext={{this.page.nextPage}}
->
-  <:previous>
-    <LinkTo
-      @route="version.show"
-      @model={{this.page.previousPage.url}}
-      class="previous-guide"
-    >
-      {{this.page.previousPage.title}}
-    </LinkTo>
-  </:previous>
+<footer>
+  <EsPagination
+    @showPrevious={{this.page.previousPage}}
+    @showNext={{this.page.nextPage}}
+  >
+    <:previous>
+      <LinkTo
+        @route="version.show"
+        @model={{this.page.previousPage.url}}
+        class="previous-guide"
+      >
+        {{this.page.previousPage.title}}
+      </LinkTo>
+    </:previous>
 
-  <:next>
-    <LinkTo
-      @route="version.show"
-      @model={{this.page.nextPage.url}}
-      class="next-guide"
-    >
-      {{#if this.page.isLastPage}}
-        We've finished covering
-        {{this.page.currentSection.title}}. Next up:
-        {{this.page.nextSection.title}}
-        -
-        {{this.page.nextPage.title}}
-      {{else if this.page.nextIsFirstPage}}
-        {{this.page.nextSection.title}}
-        -
-        {{this.page.nextPage.title}}
-      {{else}}
-        {{this.page.nextPage.title}}
-      {{/if}}
-    </LinkTo>
-  </:next>
-</EsPagination>
+    <:next>
+      <LinkTo
+        @route="version.show"
+        @model={{this.page.nextPage.url}}
+        class="next-guide"
+      >
+      {{log this.page.nextPage}}
+        {{#if this.page.isLastPage}}
+          We've finished covering
+          {{this.page.currentSection.title}}. Next up:
+          {{this.page.nextSection.title}}
+          -
+          {{this.page.nextPage.title}}
+        {{else if this.page.nextIsFirstPage}}
+          {{this.page.nextSection.title}}
+          -
+          {{this.page.nextPage.title}}
+        {{else}}
+          {{this.page.nextPage.title}}
+        {{/if}}
+      </LinkTo>
+    </:next>
+  </EsPagination>
+</footer>

--- a/guidemaker-ember-template/src/components/chapter-links.js
+++ b/guidemaker-ember-template/src/components/chapter-links.js
@@ -1,9 +1,6 @@
-/* eslint-disable ember/no-classic-components, ember/no-classic-classes, ember/require-tagless-components */
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
-export default Component.extend({
-  tagName: 'footer',
-
-  page: service(),
-});
+export default class ChapterLinksComponent extends Component {
+  @service page;
+}

--- a/guidemaker-ember-template/src/components/guides-article.hbs
+++ b/guidemaker-ember-template/src/components/guides-article.hbs
@@ -69,7 +69,7 @@
         @extensions="showdown-section-groups header-links"
       />
 
-      <ChapterLinks @pages={{@pages}} />
+      <ChapterLinks />
     </div>
     <div class="guides-article-toc">
       <OnThisPage @toc={{@model.toc}} />

--- a/test-app/tests/acceptance/chapter-links-test.js
+++ b/test-app/tests/acceptance/chapter-links-test.js
@@ -1,7 +1,39 @@
 /* eslint-disable prettier/prettier */
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
-import { visit, find } from '@ember/test-helpers';
+import { visit, find, click } from '@ember/test-helpers';
+
+const PREV_LINK_TEXTS = [
+  null,
+  'Guides',
+  'Introduction',
+  'Editing',
+  'Introduction',
+  'Page 1',
+  'Introduction',
+  'Page 2',
+  'Page 3',
+  'Basic Markdown',
+  'Code Syntax Highlighting',
+  'Callouts',
+  'Video',
+];
+
+const NEXT_LINK_TEXTS = [
+  "We've finished covering Guides and Tutorials. Next up: Getting Started - Introduction",
+  'Editing',
+  "We've finished covering Getting Started. Next up: Another Section - Introduction",
+  'Page 1',
+  'Subsection - Introduction',
+  'Page 2',
+  "We've finished covering Subsection. Next up: Another Section - Page 3",
+  "We've finished covering Another Section. Next up: Examples - Basic Markdown",
+  'Code Syntax Highlighting',
+  'Callouts',
+  'Video',
+  "We've finished covering Examples. Next up: Guide test - Sidebar stress test",
+  null,
+];
 
 module('Acceptance | chapter-links', function (hooks) {
   setupApplicationTest(hooks);
@@ -9,62 +41,24 @@ module('Acceptance | chapter-links', function (hooks) {
   test('chapter links are correct', async function (assert) {
     await visit('/release');
 
-    let prevLinkTexts = [];
-    let nextLinkTexts = [];
+    let index = 0;
+    while (index >= 0) {
+      const prevLink = find('.prev-guide');
+      const nextLink = find('.next-guide');
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      let prevLink = find('.previous-guide');
-      let nextLink = find('.next-guide');
-
-      prevLinkTexts.push(prevLink && prevLink.textContent.trim());
-      nextLinkTexts.push(nextLink && nextLink.textContent.trim());
-
+      if (prevLink) {
+        assert.dom('.previous-guide').hasText(PREV_LINK_TEXTS[index]);
+      }
       if (nextLink) {
-        await visit(nextLink.attributes.href.value);
+        assert.dom('.next-guide').hasText(NEXT_LINK_TEXTS[index]);
+      }
+
+      index++;
+      if (nextLink) {
+        await click(nextLink);
       } else {
         break;
       }
     }
-
-    assert.deepEqual(
-      prevLinkTexts,
-      [
-        null,
-        'Guides',
-        'Introduction',
-        'Editing',
-        'Introduction',
-        'Page 1',
-        'Introduction',
-        'Page 2',
-        'Page 3',
-        'Basic Markdown',
-        'Code Syntax Highlighting',
-        'Callouts',
-        'Video',
-      ],
-      'previous link texts were correct',
-    );
-
-    assert.deepEqual(
-      nextLinkTexts,
-      [
-        "We've finished covering Guides and Tutorials. Next up: Getting Started - Introduction",
-        'Editing',
-        "We've finished covering Getting Started. Next up: Another Section - Introduction",
-        'Page 1',
-        'Subsection - Introduction',
-        'Page 2',
-        "We've finished covering Subsection. Next up: Another Section - Page 3",
-        "We've finished covering Another Section. Next up: Examples - Basic Markdown",
-        'Code Syntax Highlighting',
-        'Callouts',
-        'Video',
-        "We've finished covering Examples. Next up: Guide test - Sidebar stress test",
-        null,
-      ],
-      'next link texts were correct',
-    );
   });
 });

--- a/test-app/tests/integration/components/chapter-links-test.js
+++ b/test-app/tests/integration/components/chapter-links-test.js
@@ -1,0 +1,72 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import Service from '@ember/service';
+
+// Stub page service
+class PageStub extends Service {
+  isLastPage = false;
+  currentSection = {
+    title: 'Current Section',
+  };
+  nextSection = {
+    title: 'Next Section',
+  };
+  previousPage = {
+    url: 'previous-url/index',
+    title: 'Previous Page',
+  };
+  nextPage = {
+    url: 'next-url/index',
+    title: 'Next Page',
+  };
+}
+
+module('Integration | Component | chapter-links', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders and empty wrapper if nextPage and previousPage does not exist', async function (assert) {
+    await render(hbs`<ChapterLinks />`);
+
+    assert.dom('.pagination-wrapper').exists();
+    assert.dom('.previous-guide').doesNotExist();
+    assert.dom('.next-guide').doesNotExist();
+  });
+
+  test('it renders the next and previous link', async function (assert) {
+    this.owner.register('service:page', PageStub);
+
+    await render(hbs`<ChapterLinks />`);
+
+    assert.dom('.pagination-wrapper').exists();
+    assert.dom('.previous-guide').exists();
+    assert.dom('.next-guide').exists();
+  });
+
+  test('it renders the isLastPage section link label', async function (assert) {
+    this.owner.register('service:page', PageStub);
+
+    this.pageService = this.owner.lookup('service:page', PageStub);
+    this.pageService.isLastPage = true;
+
+    await render(hbs`<ChapterLinks />`);
+
+    assert
+      .dom('.next-guide')
+      .hasText(
+        "We've finished covering Current Section. Next up: Next Section - Next Page",
+      );
+  });
+
+  test('it renders the isFistPage link label', async function (assert) {
+    this.owner.register('service:page', PageStub);
+
+    this.pageService = this.owner.lookup('service:page', PageStub);
+    this.pageService.nextIsFirstPage = true;
+
+    await render(hbs`<ChapterLinks />`);
+
+    assert.dom('.next-guide').hasText('Next Section - Next Page');
+  });
+});


### PR DESCRIPTION
For better readability, I have only formatted the the code in the first commit. I would recommend to ignore whitespaces.