### PR TITLE
adjust test matrix to reflect current supported ember versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
           - ember-lts-4.8
           - ember-lts-4.12
           - ember-lts-5.4
-          - ember-release
+          - ember-lts-5.12
           - embroider-safe
           - no-deprecations
 
@@ -105,6 +105,7 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
+          - ember-release
           - ember-beta
           - ember-canary
           - ember-release-no-deprecations

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -49,6 +49,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-5.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.12.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
 - add lts-5.12 because it's the newest supported ember
 - move ember-release to allowed failures because 6.0 is not yet supported