### PR TITLE
[FEATURE GJS Banner] add GJS Format banner for currentVersion

### DIFF
--- a/guidemaker-ember-template/src/components/guides-article.hbs
+++ b/guidemaker-ember-template/src/components/guides-article.hbs
@@ -34,7 +34,7 @@
           </LinkTo>
         </div>
       {{/unless}}
-      {{#if (eq @version @currentVersion)}}
+      {{#if this.showGJSBanner}}
         <div
           class="info-banner-wrapper"
           role="region"
@@ -61,7 +61,9 @@
               This guide is written assuming you are using GJS in your app. See
               this
               <a
-                href="/components/template-tag-format/"
+                href={{this.gjsLink}}
+                target="_blank"
+                rel="noopener noreferrer"
                 class="info-banner-link"
               >page</a>
               to read more about GJS.

--- a/guidemaker-ember-template/src/components/guides-article.hbs
+++ b/guidemaker-ember-template/src/components/guides-article.hbs
@@ -29,10 +29,46 @@
             @models={{array "release" @path}}
             class="es-button-secondary old-version-button"
           >
-            Go to {{@currentVersion}}
+            Go to
+            {{@currentVersion}}
           </LinkTo>
         </div>
       {{/unless}}
+      {{#if (eq @version @currentVersion)}}
+        <div
+          class="info-banner-wrapper"
+          role="region"
+          aria-label="GJS Info Banner"
+          tabindex="0"
+        >
+          <div class="info-banner-text">
+            <svg
+              aria-hidden="true"
+              focusable="false"
+              data-prefix="fas"
+              data-icon="exclamation-circle"
+              class="info-banner-icon"
+              role="img"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 512 512"
+            >
+              <path
+                d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+              ></path>
+            </svg>
+            <div>
+              <strong>GJS Format - </strong>
+              This guide is written assuming you are using GJS in your app. See
+              this
+              <a
+                href="/components/template-tag-format/"
+                class="info-banner-link"
+              >page</a>
+              to read more about GJS.
+            </div>
+          </div>
+        </div>
+      {{/if}}
 
       <div class="article-title">
         <h1>

--- a/guidemaker-ember-template/src/components/guides-article.js
+++ b/guidemaker-ember-template/src/components/guides-article.js
@@ -1,9 +1,23 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 
+// TODO remove this and use appEmberSatisfies() from @embroider/macros when it's done
+import config from 'ember-get-config';
+
 export default class GuidesArticleComponent extends Component {
   @service page;
   @service guidemaker;
+
+  get gjsLink() {
+    return config?.guidemaker?.gjsLink;
+  }
+
+  get showGJSBanner() {
+    return (
+      Array.isArray(config?.guidemaker?.gjsVersions) &&
+      Boolean(config.guidemaker.gjsVersions.includes(this.args.version))
+    );
+  }
 
   get editVersion() {
     if (this.page.currentVersion === 'release') {

--- a/guidemaker-ember-template/src/styles/addon.css
+++ b/guidemaker-ember-template/src/styles/addon.css
@@ -23,8 +23,10 @@
   align-items: center;
 }
 
-.old-version-warning .warning-icon {
+.old-version-warning .warning-icon,
+.info-banner-wrapper .info-banner-icon {
   height: 1.5rem;
+  flex: none;
   margin-right: 8px;
   fill: var(--color-blue-dark);
 }
@@ -34,7 +36,8 @@ a.old-version-button, a.old-version-button:link, a.old-version-button:visited {
   color: var(--color-blue-dark);
 }
 
-a.old-version-button:hover, a.old-version-button:active {
+a.old-version-button:hover,
+a.old-version-button:active {
   background-color: var(--color-blue-dark);
   color: var(--color-button-secondary-text-hover);
 }
@@ -56,10 +59,20 @@ a.old-version-button:hover, a.old-version-button:active {
 }
 
 .info-banner-wrapper {
-  margin: var(--spacing-1);
-  padding: var(--spacing-1);
   background-color: var(--color-info);
-  border-radius: var(--radius-lg);
+  padding: 8px 12px;
+  border-radius: 4px;
+  margin-bottom: var(--spacing-3);
+}
+
+.info-banner-text {
+  display: flex;
+  align-items: center;
+}
+
+.info-banner-link {
+  color: var(--color-blue-dark);
+  text-decoration: underline;
 }
 
 @media (min-width: 30em) and (max-width: 85em) {
@@ -98,7 +111,7 @@ a.old-version-button:hover, a.old-version-button:active {
 
 /* TODO figure out how much of this media query needs to go into the styleguide */
 @media (max-width: 844px) {
-  main .es-sidebar[aria-expanded="true"] {
+  main .es-sidebar[aria-expanded='true'] {
     padding: var(--spacing-2);
     z-index: 1;
     display: flex;
@@ -126,7 +139,7 @@ a.old-version-button:hover, a.old-version-button:active {
 @media screen and (min-width: 54em) {
   .sidebar {
     border-bottom: 0;
-    border-right: 1px solid #F8E7CF;
+    border-right: 1px solid #f8e7cf;
     padding: 3em 1.618em 3em 0;
   }
 
@@ -134,7 +147,7 @@ a.old-version-button:hover, a.old-version-button:active {
     margin-right: 0;
   }
 
-  label[for="toc-toggle"] {
+  label[for='toc-toggle'] {
     display: none;
   }
 
@@ -227,18 +240,17 @@ h6 > a:hover > svg {
   fill: var(--color-brand);
 }
 
-
 /* table styles  */
 table {
   width: 100%;
   text-align: left;
   border-collapse: collapse;
 }
-thead th{
+thead th {
   background-color: var(--color-gray-200);
 }
-td, th {
+td,
+th {
   border: 1px solid var(--color-gray-300);
   padding: var(--spacing-1);
 }
-

--- a/test-app/config/environment.js
+++ b/test-app/config/environment.js
@@ -26,6 +26,9 @@ module.exports = function (environment) {
     guidemaker: {
       title: 'Ember Guidemaker Template',
       sourceRepo: 'https://github.com/ember-learn/guidemaker-ember-template',
+      gjsVersions: ['v1.2.0'],
+      gjsLink:
+        'https://guides.emberjs.com/release/components/template-tag-format/',
     },
 
     algolia: {


### PR DESCRIPTION
<img width="1372" height="357" alt="Screenshot 2025-09-18 at 5 21 59 PM" src="https://github.com/user-attachments/assets/aa1d3463-fcad-472d-9b31-e1ae3d2de7ab" />

This pull request introduces a new informational banner to the guides article page when the current version is GJS, and updates related styles for consistency and improved accessibility. The most significant changes are the addition of the GJS info banner component, updates to CSS for the new banner, and several minor style consistency improvements.

**Feature addition:**

* Added a conditional info banner to `guides-article.hbs` that appears when the current version is GJS, informing users that the guide assumes GJS usage and linking to more information. The banner includes an accessible SVG icon and appropriate ARIA labels.

**Styling and consistency improvements:**

* Updated `.info-banner-wrapper` and related CSS classes in `addon.css` to style the new info banner, including layout, padding, border radius, and link appearance.
* Modified the shared icon styles so that both the old version warning and info banner icons are consistently sized and aligned.
* Improved formatting and consistency in CSS selectors and properties, such as spacing, color codes, and selector quoting, to align with project style guidelines. [[1]](diffhunk://#diff-fb63afead330e967bd864369cfa1af44d50f0f20e44fbf726658f770df5c4b11L37-R40) [[2]](diffhunk://#diff-fb63afead330e967bd864369cfa1af44d50f0f20e44fbf726658f770df5c4b11L101-R114) [[3]](diffhunk://#diff-fb63afead330e967bd864369cfa1af44d50f0f20e44fbf726658f770df5c4b11L129-R150) [[4]](diffhunk://#diff-fb63afead330e967bd864369cfa1af44d50f0f20e44fbf726658f770df5c4b11L230) [[5]](diffhunk://#diff-fb63afead330e967bd864369cfa1af44d50f0f20e44fbf726658f770df5c4b11L240-L244)